### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Const labels
 
 When you create a `collector` you can put to than collector constant labels,
 these constant labels will apply to all the metrics gathered by that collector
-appart from the ones that we put. For example this example without const labels
+apart from the ones that we put. For example this example without const labels
 
 ```python
     ram_metric = Gauge("memory_usage_bytes", "Memory usage in bytes.")


### PR DESCRIPTION
@slok, I've corrected a typographical error in the documentation of the [prometheus-python](https://github.com/slok/prometheus-python) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
